### PR TITLE
Update main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,9 @@
 function getWidth() {
-  return screen.width * devicePixelRatio;
+  return screen.width;
 }
 
 function getHeight() {
-  return screen.height * devicePixelRatio;
+  return screen.height;
 }
 
 function is4k() {


### PR DESCRIPTION
Screen.width returns the width, no need to multiply it by device pixel ratio

> The Screen.width read-only property returns the width of the screen in pixels.
https://developer.mozilla.org/en-US/docs/Web/API/Screen/width